### PR TITLE
Correctly set the subnet mask on the interfaces used by DHCP.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+neutron (1:2014.1-0ubuntu1-calico0.2) trusty; urgency=medium
+
+  * DHCP agent: correctly set the subnet mask on the interfaces used by DHCP.
+
+ -- Cory Benfield <cory.benfield@metaswitch.com>  Thu, 03 Jul 2014 15:02:05 +0100
+
 neutron (1:2014.1-0ubuntu1-calico0.1) trusty; urgency=medium
 
   * Add VIF_TYPE constant for routed virtual interfaces.

--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -899,7 +899,8 @@ class DeviceManager(object):
 
                 if subnet.ip_version == 4:
                     if gateway:
-                        ip_cidrs.append('%s/24' % gateway)
+                        net = netaddr.IPNetwork(subnet.cidr)
+                        ip_cidrs.append('%s/%s' % (gateway, net.prefixlen))
 
         if (self.driver.bridged() and
             self.conf.enable_isolated_metadata and


### PR DESCRIPTION
As discussed, this sets the appropriate subnet mask on the interfaces used by the DHCP agent.
