### PR TITLE
Patch the metadata agent and proxy to function in flat networks

### DIFF
--- a/neutron/agent/metadata/agent.py
+++ b/neutron/agent/metadata/agent.py
@@ -128,16 +128,20 @@ class MetadataProxyHandler(object):
 
         if network_id:
             networks = [network_id]
-        else:
+        elif router_id:
             internal_ports = qclient.list_ports(
                 device_id=router_id,
                 device_owner=n_const.DEVICE_OWNER_ROUTER_INTF)['ports']
 
             networks = [p['network_id'] for p in internal_ports]
 
-        ports = qclient.list_ports(
-            network_id=networks,
-            fixed_ips=['ip_address=%s' % remote_address])['ports']
+        if network_id or router_id:
+            ports = qclient.list_ports(
+                network_id=networks,
+                fixed_ips=['ip_address=%s' % remote_address])['ports']
+        else:  # Flat networks should have unique IPs.
+            ports = qclient.list_ports(
+                fixed_ips=['ip_address=%s' % remote_address])['ports']
 
         self.auth_info = qclient.get_auth_info()
         if len(ports) == 1:

--- a/neutron/agent/metadata/namespace_proxy.py
+++ b/neutron/agent/metadata/namespace_proxy.py
@@ -18,6 +18,7 @@
 
 import httplib
 import socket
+import uuid
 
 import eventlet
 import httplib2
@@ -55,11 +56,12 @@ class NetworkMetadataProxyHandler(object):
     accessible within the isolated tenant context.
     """
 
-    def __init__(self, network_id=None, router_id=None):
+    def __init__(self, network_id=None, router_id=None, flat=False):
         self.network_id = network_id
         self.router_id = router_id
+        self.flat = flat
 
-        if network_id is None and router_id is None:
+        if network_id is None and router_id is None and not flat:
             msg = _('network_id and router_id are None. One must be provided.')
             raise ValueError(msg)
 
@@ -86,7 +88,7 @@ class NetworkMetadataProxyHandler(object):
 
         if self.router_id:
             headers['X-Neutron-Router-ID'] = self.router_id
-        else:
+        elif self.network_id:
             headers['X-Neutron-Network-ID'] = self.network_id
 
         url = urlparse.urlunsplit((
@@ -127,17 +129,20 @@ class NetworkMetadataProxyHandler(object):
 
 
 class ProxyDaemon(daemon.Daemon):
-    def __init__(self, pidfile, port, network_id=None, router_id=None):
-        uuid = network_id or router_id
-        super(ProxyDaemon, self).__init__(pidfile, uuid=uuid)
+    def __init__(self, pidfile, port, network_id=None, router_id=None,
+                 flat=False):
+        this_uuid = network_id or router_id or uuid.uuid4()
+        super(ProxyDaemon, self).__init__(pidfile, uuid=this_uuid)
         self.network_id = network_id
         self.router_id = router_id
+        self.flat = flat
         self.port = port
 
     def run(self):
         handler = NetworkMetadataProxyHandler(
             self.network_id,
-            self.router_id)
+            self.router_id,
+            self.flat)
         proxy = wsgi.Server('neutron-network-metadata-proxy')
         proxy.start(handler, self.port)
         proxy.wait()
@@ -152,6 +157,10 @@ def main():
         cfg.StrOpt('router_id',
                    help=_('Router that will have connected instances\' '
                           'metadata proxied.')),
+        cfg.StrOpt('flat',
+                   default=False,
+                   help=_('Flat networking is being used: neither the network'
+                          'nor the router ID is provided.')),
         cfg.StrOpt('pid_file',
                    help=_('Location of pid file of this process.')),
         cfg.BoolOpt('daemonize',
@@ -175,7 +184,8 @@ def main():
     proxy = ProxyDaemon(cfg.CONF.pid_file,
                         cfg.CONF.metadata_port,
                         network_id=cfg.CONF.network_id,
-                        router_id=cfg.CONF.router_id)
+                        router_id=cfg.CONF.router_id,
+                        flat=cfg.CONF.flat)
 
     if cfg.CONF.daemonize:
         proxy.start()

--- a/neutron/agent/metadata/namespace_proxy.py
+++ b/neutron/agent/metadata/namespace_proxy.py
@@ -18,7 +18,6 @@
 
 import httplib
 import socket
-import uuid
 
 import eventlet
 import httplib2
@@ -56,13 +55,14 @@ class NetworkMetadataProxyHandler(object):
     accessible within the isolated tenant context.
     """
 
-    def __init__(self, network_id=None, router_id=None, flat=False):
+    def __init__(self, network_id=None, router_id=None, flat=None):
         self.network_id = network_id
         self.router_id = router_id
         self.flat = flat
 
-        if network_id is None and router_id is None and not flat:
-            msg = _('network_id and router_id are None. One must be provided.')
+        if network_id is None and router_id is None and flat is None:
+            msg = _('network_id, router_id and flat are None. One must be '
+                    'provided.')
             raise ValueError(msg)
 
     @webob.dec.wsgify(RequestClass=webob.Request)
@@ -130,8 +130,8 @@ class NetworkMetadataProxyHandler(object):
 
 class ProxyDaemon(daemon.Daemon):
     def __init__(self, pidfile, port, network_id=None, router_id=None,
-                 flat=False):
-        this_uuid = network_id or router_id or uuid.uuid4()
+                 flat=None):
+        this_uuid = network_id or router_id or flat
         super(ProxyDaemon, self).__init__(pidfile, uuid=this_uuid)
         self.network_id = network_id
         self.router_id = router_id
@@ -158,9 +158,9 @@ def main():
                    help=_('Router that will have connected instances\' '
                           'metadata proxied.')),
         cfg.StrOpt('flat',
-                   default=False,
-                   help=_('Flat networking is being used: neither the network'
-                          'nor the router ID is provided.')),
+                   help=_('Flat networking is being used: neither the network '
+                          'nor the router ID is provided. This argument takes '
+                          'a UUID to identify the instance.')),
         cfg.StrOpt('pid_file',
                    help=_('Location of pid file of this process.')),
         cfg.BoolOpt('daemonize',


### PR DESCRIPTION
This patch enables the metadata agent and the metadata namespace proxy to function correctly in flat networks.

The metadata proxy can now be launched with the `--flat` flag, which takes a UUID. This flag instructs the proxy not to bother adding headers signaling router or network. This is necessary because Calico OpenStack deployments do not have routers, and each compute node may have guests on many networks.

For the metadata agent, if it receives a proxied request with neither header it will search for the port based on source IP alone. This is acceptable because in Calico-based networks each VM IP is unique. Note that if, for some reason, a non-unique IP is received the request will be rejected.

This is part of the solution for Metaswitch/calico#3, along with Metaswitch/calico#4.
