### PR TITLE
Neutron enhancements for Calico/IPv6 connectivity

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -363,10 +363,16 @@ class Dnsmasq(DhcpLocalProcess):
                 continue
             if subnet.ip_version == 4:
                 mode = 'static'
-            else:
+            elif self.device_manager.bridged():
                 # TODO(mark): how do we indicate other options
                 # ra-only, slaac, ra-nameservers, and ra-stateless.
                 mode = 'static'
+            else:
+                # For routed IPv6 networking specify 'off-link' flag
+                # to Dnsmasq.  This results in VM adding a default
+                # route to the link-local address of the TAP interface
+                # on the compute host.
+                mode = 'static,off-link'
             if self.version >= self.MINIMUM_VERSION:
                 set_tag = 'set:'
             else:

--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -353,6 +353,7 @@ class Dnsmasq(DhcpLocalProcess):
                 '--addn-hosts=%s' % self._output_addn_hosts_file(),
                 '--dhcp-optsfile=%s' % self._output_opts_file(),
                 '--leasefile-ro',
+                '--enable-ra',
                 ]
 
         possible_leases = 0

--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -893,10 +893,9 @@ class DeviceManager(object):
                     if hr.destination == "0.0.0.0/0":
                         gateway = hr.nexthop
 
-                if subnet.ip_version == 4:
-                    if gateway:
-                        net = netaddr.IPNetwork(subnet.cidr)
-                        ip_cidrs.append('%s/%s' % (gateway, net.prefixlen))
+                if gateway:
+                    net = netaddr.IPNetwork(subnet.cidr)
+                    ip_cidrs.append('%s/%s' % (gateway, net.prefixlen))
 
         if (self.driver.bridged() and
             self.conf.enable_isolated_metadata and


### PR DESCRIPTION
This merge request contains the Neutron enhancements that are required for Calico/IPv6 connectivity. The umbrella issue for this work is at Metaswitch/calico#10.
