### PR TITLE
Remove incorrect root_helper parm, in IPDevice constructor

### DIFF
--- a/neutron/agent/linux/ip_lib.py
+++ b/neutron/agent/linux/ip_lib.py
@@ -147,7 +147,7 @@ class IPWrapper(SubProcessBase):
 
         self._as_root('', 'link', tuple(args))
 
-        return IPDevice(name1, self.root_helper, self.namespace)
+        return IPDevice(name1, self.namespace)
 
     def ensure_namespace(self, name):
         if not self.netns.exists(name):


### PR DESCRIPTION
Without this change, DHCP (for VMs) stops working when a compute is
rebooted, because the iptables rule for CHECKSUM filling does not get
recreated.
