### PR TITLE
Icehouse: Always fill UDP checksums in DHCP replies

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -29,6 +29,7 @@ from oslo.config import cfg
 import six
 
 from neutron.agent.linux import ip_lib
+from neutron.agent.linux import iptables_manager
 from neutron.agent.linux import utils
 from neutron.common import constants
 from neutron.common import exceptions
@@ -990,6 +991,7 @@ class DeviceManager(object):
                              interface_name,
                              port.mac_address,
                              namespace=network.namespace)
+            self.fill_dhcp_udp_checksums(namespace=network.namespace)
         ip_cidrs = []
         for fixed_ip in port.fixed_ips:
             subnet = fixed_ip.subnet
@@ -1049,3 +1051,12 @@ class DeviceManager(object):
 
         self.plugin.release_dhcp_port(network.id,
                                       self.get_device_id(network))
+
+    def fill_dhcp_udp_checksums(self, namespace):
+        """Ensure DHCP reply packets always have correct UDP checksums."""
+        iptables_mgr = iptables_manager.IptablesManager(use_ipv6=False,
+                                                        namespace=namespace)
+        ipv4_rule = ('-p udp --dport %d -j CHECKSUM --checksum-fill'
+                     % constants.DHCP_RESPONSE_PORT)
+        iptables_mgr.ipv4['mangle'].add_rule('POSTROUTING', ipv4_rule)
+        iptables_mgr.apply()


### PR DESCRIPTION
In some cases the UDP checksums in packets from DHCP servers are
incorrect. This is a problem for some DHCP clients that ignore
packets with bad checksums. This patch inserts an iptables rule
to ensure DHCP servers always send packets with correct checksums.

Change-Id: I130fe0f2389bdc42eb8c858ea35dd840abecc2e7
Closes-Bug: 1244589

Conflicts:
    neutron/tests/unit/test_dhcp_agent.py
