### PR TITLE
Juno (RHEL): Always fill UDP checksums in DHCP replies

### DIFF
--- a/neutron/agent/linux/dhcp.py
+++ b/neutron/agent/linux/dhcp.py
@@ -26,6 +26,7 @@ from oslo.config import cfg
 import six
 
 from neutron.agent.linux import ip_lib
+from neutron.agent.linux import iptables_manager
 from neutron.agent.linux import utils
 from neutron.common import constants
 from neutron.common import exceptions
@@ -1024,6 +1025,7 @@ class DeviceManager(object):
                              interface_name,
                              port.mac_address,
                              namespace=network.namespace)
+            self.fill_dhcp_udp_checksums(namespace=network.namespace)
         ip_cidrs = []
         for fixed_ip in port.fixed_ips:
             subnet = fixed_ip.subnet
@@ -1083,3 +1085,12 @@ class DeviceManager(object):
 
         self.plugin.release_dhcp_port(network.id,
                                       self.get_device_id(network))
+
+    def fill_dhcp_udp_checksums(self, namespace):
+        """Ensure DHCP reply packets always have correct UDP checksums."""
+        iptables_mgr = iptables_manager.IptablesManager(use_ipv6=False,
+                                                        namespace=namespace)
+        ipv4_rule = ('-p udp --dport %d -j CHECKSUM --checksum-fill'
+                     % constants.DHCP_RESPONSE_PORT)
+        iptables_mgr.ipv4['mangle'].add_rule('POSTROUTING', ipv4_rule)
+        iptables_mgr.apply()

--- a/neutron/tests/unit/test_dhcp_agent.py
+++ b/neutron/tests/unit/test_dhcp_agent.py
@@ -1324,6 +1324,14 @@ class TestDeviceManager(base.BaseTestCase):
         iproute_cls.return_value = self.mock_iproute
         self.mock_driver.bridged.return_value = True
 
+        iptables_cls_p = mock.patch(
+            'neutron.agent.linux.iptables_manager.IptablesManager')
+        iptables_cls = iptables_cls_p.start()
+        self.iptables_inst = mock.Mock()
+        iptables_cls.return_value = self.iptables_inst
+        self.mangle_inst = mock.Mock()
+        self.iptables_inst.ipv4 = {'mangle': self.mangle_inst}
+
     def _test_setup_helper(self, device_is_ready, net=None, port=None):
         net = net or fake_network
         port = port or fake_port1
@@ -1372,6 +1380,13 @@ class TestDeviceManager(base.BaseTestCase):
         self._test_setup_helper(False)
         cfg.CONF.set_override('enable_metadata_network', True)
         self._test_setup_helper(False)
+
+    def test_setup_calls_fill_dhcp_udp_checksums(self):
+        self._test_setup_helper(False)
+        rule = ('-p udp --dport %d -j CHECKSUM --checksum-fill'
+                % const.DHCP_RESPONSE_PORT)
+        expected = [mock.call.add_rule('POSTROUTING', rule)]
+        self.mangle_inst.assert_has_calls(expected)
 
     def test_setup_device_is_ready(self):
         self._test_setup_helper(True)


### PR DESCRIPTION
In some cases the UDP checksums in packets from DHCP servers are
incorrect. This is a problem for some DHCP clients that ignore
packets with bad checksums. This patch inserts an iptables rule
to ensure DHCP servers always send packets with correct checksums.

Change-Id: I130fe0f2389bdc42eb8c858ea35dd840abecc2e7
Closes-Bug: 1244589

Conflicts:
    neutron/tests/unit/test_dhcp_agent.py
